### PR TITLE
Fix: copr download vendor on rpm source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DIST_DIR = $(shell pwd)/dist
 
 node_exporter:
 	git clone -b v$(VERSION) https://github.com/prometheus/node_exporter.git
+	cd node_exporter; go mod vendor
 
 rpm-tarball: node_exporter
 	cp -R node_exporter.service node_exporter

--- a/node_exporter.spec
+++ b/node_exporter.spec
@@ -18,12 +18,12 @@ Provides:       golang(%{go_import_path}) = %{version}-%{release}
 %description
 The Prometheus Node Exporter collects and exposes system metrics.
 
-%prep 
+%prep
 tar fx %{SOURCE0}
 
 %build
 cd %{name}-%{VERSION}
-go build
+go build --mod=vendor
 
 %install
 cd %{name}-%{VERSION}


### PR DESCRIPTION
On air-gapped build the build was failing because cannot download vendor
sources from internet. This commit fixes the issues with COPR.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>